### PR TITLE
1) XEC denominated balance and send (minimal)

### DIFF
--- a/src/components/admin-lte/configure/servers.js
+++ b/src/components/admin-lte/configure/servers.js
@@ -46,7 +46,7 @@ class Servers extends React.Component {
                 </h1>
                 <p>
                   Currently connected to the
-                  {_this.props.walletInfo.selectedServer ==
+                  {_this.props.walletInfo.selectedServer ===
                   'https://bchn.fullstack.cash/v5/'
                     ? ' Bitcoin Cash '
                     : ' Ecash '}

--- a/src/components/admin-lte/configure/servers.js
+++ b/src/components/admin-lte/configure/servers.js
@@ -44,6 +44,14 @@ class Servers extends React.Component {
                   />
                   <span>Back End Server</span>
                 </h1>
+                <p>
+                  Currently connected to the
+                  {_this.props.walletInfo.selectedServer ==
+                  'https://bchn.fullstack.cash/v5/'
+                    ? ' Bitcoin Cash '
+                    : ' Ecash '}
+                  network.
+                </p>
                 <Box className='border-none'>
                   <Row>
                     <Col xs={12}>

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -81,7 +81,11 @@ class AdminLTEPage extends React.Component {
                           </h3>
 
                           <span style={{ fontSize: '18px' }}>
-                            {_this.state.bchBalance}
+                          {_this.props.walletInfo.selectedServer ===
+                            'https://bchn.fullstack.cash/v5/'
+                              ? _this.state.bchBalance
+                              : _this.state.bchBalance * 1000000
+                            }
                           </span>
                           <small>USD: ${_this.state.usdBalance}</small>
                         </span>

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -74,7 +74,7 @@ class AdminLTEPage extends React.Component {
                       <div className='siderbar-balance-content'>
                         <span>
                           <h3>
-                            {_this.props.walletInfo.selectedServer ==
+                            {_this.props.walletInfo.selectedServer ===
                             'https://bchn.fullstack.cash/v5/'
                               ? 'BCH Balance'
                               : 'XEC Balance'}
@@ -241,9 +241,10 @@ class AdminLTEPage extends React.Component {
       if (childrens && childrens.length) {
         for (let i = 0; i < childrens.length; i++) {
           // const href = childrens[i].children[0].href
-          const textValue = childrens[i].children[0].children[1].textContent
+          let textValue = childrens[i].children[0].children[1].textContent
           childrens[i].id = textValue
           const ignore = ignoreItems.find(val => textValue === val)
+          if (textValue === 'Send/Receive XEC') textValue = 'Send/Receive BCH'
           // Ignore menu items without link to components
           if (!ignore && childrens[i]) {
             childrens[i].onclick = () => this.changeSection(textValue)

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -81,11 +81,10 @@ class AdminLTEPage extends React.Component {
                           </h3>
 
                           <span style={{ fontSize: '18px' }}>
-                          {_this.props.walletInfo.selectedServer ===
+                            {_this.props.walletInfo.selectedServer ===
                             'https://bchn.fullstack.cash/v5/'
                               ? _this.state.bchBalance
-                              : _this.state.bchBalance * 1000000
-                            }
+                              : (_this.state.bchBalance * 1000000).toFixed(2)}
                           </span>
                           <small>USD: ${_this.state.usdBalance}</small>
                         </span>

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -73,7 +73,12 @@ class AdminLTEPage extends React.Component {
                     {!_this.state.inFetch && (
                       <div className='siderbar-balance-content'>
                         <span>
-                          <h3>{siteConfig.balanceText}</h3>
+                          <h3>
+                            {_this.props.walletInfo.selectedServer ==
+                            'https://bchn.fullstack.cash/v5/'
+                              ? 'BCH Balance'
+                              : 'XEC Balance'}
+                          </h3>
 
                           <span style={{ fontSize: '18px' }}>
                             {_this.state.bchBalance}

--- a/src/components/admin-lte/send-receive/index.js
+++ b/src/components/admin-lte/send-receive/index.js
@@ -22,6 +22,7 @@ class SendReceive extends React.Component {
             <Content>
               <Receive walletInfo={_this.props.walletInfo} />
               <Send
+                walletInfo={_this.props.walletInfo}
                 updateBalance={_this.props.updateBalance}
                 bchWallet={_this.props.bchWallet}
                 currentRate={_this.props.currentRate}

--- a/src/components/admin-lte/send-receive/send.js
+++ b/src/components/admin-lte/send-receive/send.js
@@ -15,14 +15,23 @@ class Send extends React.Component {
 
     _this = this
 
+    const coin = _this.props.walletInfo.selectedServer === 'https://bchn.fullstack.cash/v5/'
+      ? 'BCH'
+      : 'XEC'
+
+    const unitConversion = coin === 'XEC' ? 1 / 1000000 : 1
+    // for the conversion of Bcha price to Xec denomination
+
     this.state = {
       address: '',
+      unitConversion: unitConversion,
       amountSat: '',
       errMsg: '',
       txId: '',
       showScan: false,
       inFetch: false,
       sendCurrency: 'USD',
+      coin: coin,
       sendMax: false,
       explorerURL: ''
     }
@@ -54,8 +63,8 @@ class Send extends React.Component {
                       <Text
                         id='addressToSend'
                         name='address'
-                        placeholder='Enter bch address to send'
-                        label='BCH Address'
+                        placeholder={`Enter ${_this.state.coin} address to send`}
+                        label={`${_this.state.coin} Address`}
                         labelPosition='above'
                         onChange={_this.handleUpdate}
                         className='title-icon'
@@ -92,14 +101,16 @@ class Send extends React.Component {
                       />
                       <div className='text-left pb-4'>
                         <p>
-                          {_this.state.sendCurrency === 'BCH'
+                          {_this.state.sendCurrency === _this.state.coin
                             ? `USD: ${(
                                 _this.state.amountSat *
-                                (_this.props.currentRate / 100)
+                                (_this.props.currentRate *
+                                  _this.state.unitConversion / 100)
                               ).toFixed(2)}`
-                            : `BCH: ${(
+                            : `${_this.state.coin}: ${(
                                 _this.state.amountSat /
-                                (_this.props.currentRate / 100)
+                                (_this.props.currentRate *
+                                  _this.state.unitConversion / 100)
                               ).toFixed(8)}`}
                         </p>
                       </div>
@@ -169,13 +180,14 @@ class Send extends React.Component {
   handleChangeCurrency () {
     if (_this.state.sendCurrency === 'USD') {
       _this.setState({
-        sendCurrency: 'BCH'
+        sendCurrency: `${_this.state.coin}`
       })
       if (_this.state.amountSat > 0) {
         _this.setState({
           amountSat: (
             _this.state.amountSat /
-            (_this.props.currentRate / 100)
+            (_this.props.currentRate *
+              _this.state.unitConversion / 100)
           ).toFixed(8)
         })
       }
@@ -187,7 +199,8 @@ class Send extends React.Component {
         _this.setState({
           amountSat: (
             _this.state.amountSat *
-            (_this.props.currentRate / 100)
+            (_this.props.currentRate *
+              _this.state.unitConversion / 100)
           ).toFixed(2)
         })
       }
@@ -217,7 +230,7 @@ class Send extends React.Component {
 
       const utxos = bchWalletLib.utxos.utxoStore.bchUtxos
       if (!utxos.length) {
-        throw new Error('No BCH Utxos to spend!')
+        throw new Error(`No ${_this.state.coin} Utxos to spend!`)
       }
 
       // Get total of satoshis fron the bch utxos
@@ -257,7 +270,12 @@ class Send extends React.Component {
         amountSat = (amountSat / (_this.props.currentRate / 100)).toFixed(8)
       }
 
-      const amountToSend = Math.floor(Number(amountSat) * 100000000)
+      let amountToSend = Math.floor(Number(amountSat) * 100000000)
+
+      if (_this.state.coin === 'XEC') {
+        amountToSend = Math.floor(Number(amountSat) * 100)
+      }
+
       console.log(`Sending ${amountToSend} satoshis to ${address}`)
 
       if (!bchWalletLib) {
@@ -320,7 +338,12 @@ class Send extends React.Component {
         amountSat = (amountSat / (_this.props.currentRate / 100)).toFixed(8)
       }
 
-      const amountToSend = Math.floor(Number(amountSat) * 100000000)
+      let amountToSend = Math.floor(Number(amountSat) * 100000000)
+
+      if (_this.state.coin === 'XEC') {
+        amountToSend = Math.floor(Number(amountSat) * 100)
+      }
+
       console.log(`Sending ${amountToSend} satoshis to ${address}`)
 
       const receivers = [

--- a/src/components/admin-lte/wallet/index.js
+++ b/src/components/admin-lte/wallet/index.js
@@ -19,7 +19,7 @@ class Wallet extends React.Component {
   render() {
     return (
       <Content>
-        <InfoWallets />
+        <InfoWallets walletInfo={_this.props.walletInfo} />
         {/* Show wallet info is this exists */}
         {_this.props.walletInfo.mnemonic && (
           <WalletInfo walletInfo={_this.props.walletInfo} />

--- a/src/components/admin-lte/wallet/info.js
+++ b/src/components/admin-lte/wallet/info.js
@@ -3,8 +3,13 @@ import React from 'react'
 import { Row, Col, Box } from 'adminlte-2-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
+let _this
 class InfoWallets extends React.Component {
-  // state = {}
+  constructor(props) {
+    super(props)
+    _this = this
+    this.state = {}
+  }
 
   render () {
     return (
@@ -26,8 +31,12 @@ class InfoWallets extends React.Component {
 
               <Col sm={12} className='text-center mt-2 mb-2'>
                 <p>
-                  This is an open source, non-custodial web wallet
-                  supporting Bitcoin Cash (BCH) and SLP tokens. Web wallets
+                  This is an open source, non-custodial web wallet supporting
+                  {_this.props.walletInfo.selectedServer ==
+                  'https://bchn.fullstack.cash/v5/'
+                    ? ' Bitcoin Cash (BCH) '
+                    : ' Ecash (XEC) '}
+                  and SLP tokens. Web wallets
                   offer user convenience, but they are inherently insecure and
                   bad for privacy.{' '}
                   <b>Storing large amounts of money on a web wallet is not

--- a/src/components/admin-lte/wallet/info.js
+++ b/src/components/admin-lte/wallet/info.js
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 let _this
 class InfoWallets extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
     _this = this
     this.state = {}
@@ -32,7 +32,7 @@ class InfoWallets extends React.Component {
               <Col sm={12} className='text-center mt-2 mb-2'>
                 <p>
                   This is an open source, non-custodial web wallet supporting
-                  {_this.props.walletInfo.selectedServer ==
+                  {_this.props.walletInfo.selectedServer ===
                   'https://bchn.fullstack.cash/v5/'
                     ? ' Bitcoin Cash (BCH) '
                     : ' Ecash (XEC) '}

--- a/src/components/menu-components.js
+++ b/src/components/menu-components.js
@@ -21,7 +21,12 @@ const MenuComponents = props => {
       key: 'Send/Receive BCH',
       component: <SendReceive key='Send/Receive BCH' {...props} />,
       menuItem: (
-        <Item icon='fa-exchange-alt' key='Send/Receive BCH' text='Send/Receive BCH' />
+        <Item icon='fa-exchange-alt' key='Send/Receive BCH' text={`Send/Receive ${
+          props.walletInfo.selectedServer == 'https://bchn.fullstack.cash/v5/'
+            ? 'BCH'
+            : 'XEC'
+          }`} 
+        />
       )
     },
     {

--- a/src/components/menu-components.js
+++ b/src/components/menu-components.js
@@ -21,11 +21,12 @@ const MenuComponents = props => {
       key: 'Send/Receive BCH',
       component: <SendReceive key='Send/Receive BCH' {...props} />,
       menuItem: (
-        <Item icon='fa-exchange-alt' key='Send/Receive BCH' text={`Send/Receive ${
-          props.walletInfo.selectedServer == 'https://bchn.fullstack.cash/v5/'
+        <Item
+          icon='fa-exchange-alt' key='Send/Receive BCH' text={`Send/Receive ${
+          props.walletInfo.selectedServer === 'https://bchn.fullstack.cash/v5/'
             ? 'BCH'
             : 'XEC'
-          }`} 
+          }`}
         />
       )
     },

--- a/src/components/site-config.js
+++ b/src/components/site-config.js
@@ -6,7 +6,6 @@
 const config = {
   title: 'FullStack.cash',
   titleShort: 'PSF',
-  balanceText: 'BCH Balance',
   balanceIcon: 'fab-bitcoin',
 
   // The BCH address used in a memo.cash account. Used for tracking the IPFS


### PR DESCRIPTION
Builds further on the rebranding to XEC of PR #153.

Minimal alternative to #156.
This version keeps the store balance and current rate in the BCHA denomination.

- To get the balance to display the BCHA 'bchbalance' is multiplied by one million
- The conversion from entered amount to satoshis is only times a hundred for XEC
- Every calculation involving the current rate on the send sectionneeds a 'unitConversion' 
This converts the BCHA rate to the XEC rate by multiplying it by a millionth, and is just 1 when the BCH network is selected.

The change overlaps with the alternative in that the renaming of the labels and buttons in the send section works the same.

I tend to prefer this approach, but I'm curious what a reviewer thinks.
 