### PR TITLE
2) XEC denominated balance and send (comprehensive)

### DIFF
--- a/src/components/admin-lte/configure/servers.js
+++ b/src/components/admin-lte/configure/servers.js
@@ -46,7 +46,7 @@ class Servers extends React.Component {
                 </h1>
                 <p>
                   Currently connected to the
-                  {_this.props.walletInfo.selectedServer ==
+                  {_this.props.walletInfo.selectedServer ===
                   'https://bchn.fullstack.cash/v5/'
                     ? ' Bitcoin Cash '
                     : ' Ecash '}

--- a/src/components/admin-lte/configure/servers.js
+++ b/src/components/admin-lte/configure/servers.js
@@ -44,6 +44,14 @@ class Servers extends React.Component {
                   />
                   <span>Back End Server</span>
                 </h1>
+                <p>
+                  Currently connected to the
+                  {_this.props.walletInfo.selectedServer ==
+                  'https://bchn.fullstack.cash/v5/'
+                    ? ' Bitcoin Cash '
+                    : ' Ecash '}
+                  network.
+                </p>
                 <Box className='border-none'>
                   <Row>
                     <Col xs={12}>

--- a/src/components/admin-lte/configure/servers.js
+++ b/src/components/admin-lte/configure/servers.js
@@ -300,18 +300,20 @@ class Servers extends React.Component {
         const bchjs = bchWalletLib.bchjs
 
         let currentRate
+        let currency
 
         if (bchjs.restURL.includes('abc.fullstack')) {
-          currentRate = (await bchjs.Price.getBchaUsd()) * 100
+          currency = 'XEC'
+          currentRate = (await bchjs.Price.getXecUsd()) * 100
         } else {
-          // BCHN price.
+          currency = 'BCH'
           currentRate = (await bchjs.Price.getUsd()) * 100
         }
 
         _this.setState({
           currentRate: currentRate
         })
-        _this.props.updateBalance({ myBalance, currentRate })
+        _this.props.updateBalance({ myBalance, currentRate, currency })
       }
       // Hide loader spinner
       _this.setState({

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -140,18 +140,20 @@ class AdminLTEPage extends React.Component {
         const bchjs = bchWalletLib.bchjs
 
         let currentRate
+        let currency
 
         if (bchjs.restURL.includes('abc.fullstack')) {
-          currentRate = (await bchjs.Price.getBchaUsd()) * 100
+          currency = 'XEC'
+          currentRate = (await bchjs.Price.getXecUsd()) * 100
         } else {
-          // BCHN price.
+          currency = 'BCH'
           currentRate = (await bchjs.Price.getUsd()) * 100
         }
 
         _this.setState({
           currentRate: currentRate
         })
-        _this.props.updateBalance({ myBalance, currentRate })
+        _this.props.updateBalance({ myBalance, currentRate, currency })
       }
 
       _this.setState({

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -74,7 +74,7 @@ class AdminLTEPage extends React.Component {
                       <div className='siderbar-balance-content'>
                         <span>
                           <h3>
-                            {_this.props.walletInfo.selectedServer ==
+                            {_this.props.walletInfo.selectedServer ===
                             'https://bchn.fullstack.cash/v5/'
                               ? 'BCH Balance'
                               : 'XEC Balance'}
@@ -241,9 +241,10 @@ class AdminLTEPage extends React.Component {
       if (childrens && childrens.length) {
         for (let i = 0; i < childrens.length; i++) {
           // const href = childrens[i].children[0].href
-          const textValue = childrens[i].children[0].children[1].textContent
+          let textValue = childrens[i].children[0].children[1].textContent
           childrens[i].id = textValue
           const ignore = ignoreItems.find(val => textValue === val)
+          if (textValue === 'Send/Receive XEC') textValue = 'Send/Receive BCH'
           // Ignore menu items without link to components
           if (!ignore && childrens[i]) {
             childrens[i].onclick = () => this.changeSection(textValue)

--- a/src/components/admin-lte/index.js
+++ b/src/components/admin-lte/index.js
@@ -73,7 +73,12 @@ class AdminLTEPage extends React.Component {
                     {!_this.state.inFetch && (
                       <div className='siderbar-balance-content'>
                         <span>
-                          <h3>{siteConfig.balanceText}</h3>
+                          <h3>
+                            {_this.props.walletInfo.selectedServer ==
+                            'https://bchn.fullstack.cash/v5/'
+                              ? 'BCH Balance'
+                              : 'XEC Balance'}
+                          </h3>
 
                           <span style={{ fontSize: '18px' }}>
                             {_this.state.bchBalance}

--- a/src/components/admin-lte/send-receive/index.js
+++ b/src/components/admin-lte/send-receive/index.js
@@ -22,6 +22,7 @@ class SendReceive extends React.Component {
             <Content>
               <Receive walletInfo={_this.props.walletInfo} />
               <Send
+                walletInfo={_this.props.walletInfo}
                 updateBalance={_this.props.updateBalance}
                 bchWallet={_this.props.bchWallet}
                 currentRate={_this.props.currentRate}

--- a/src/components/admin-lte/wallet/create.js
+++ b/src/components/admin-lte/wallet/create.js
@@ -110,18 +110,20 @@ class NewWallet extends React.Component {
       const bchjs = bchWalletLib.bchjs
 
       let currentRate
+      let currency
 
       if (bchjs.restURL.includes('abc.fullstack')) {
-        currentRate = await bchjs.Price.getBchaUsd() * 100
+        currency = 'XEC'
+        currentRate = (await bchjs.Price.getXecUsd()) * 100
       } else {
-        // BCHN price.
+        currency = 'BCH'
         currentRate = (await bchjs.Price.getUsd()) * 100
       }
 
       // console.log("myBalance", myBalance)
       // Update redux state
       _this.props.setWalletInfo(currentWallet)
-      _this.props.updateBalance({ myBalance, currentRate })
+      _this.props.updateBalance({ myBalance, currentRate, currency })
       _this.props.setBchWallet(bchWalletLib)
 
       _this.setState({

--- a/src/components/admin-lte/wallet/import.js
+++ b/src/components/admin-lte/wallet/import.js
@@ -145,22 +145,24 @@ class ImportWallet extends React.Component {
 
       const myBalance = await bchWalletLib.getBalance()
       const bchjs = bchWalletLib.bchjs
+
       let currentRate
+      let currency
 
       if (bchjs.restURL.includes('abc.fullstack')) {
-        currentRate = (await bchjs.Price.getBchaUsd()) * 100
+        currency = 'XEC'
+        currentRate = (await bchjs.Price.getXecUsd()) * 100
       } else {
-        // BCHN price.
+        currency = 'BCH'
         currentRate = (await bchjs.Price.getUsd()) * 100
       }
 
       _this.setState({
         currentRate: currentRate
       })
-      _this.props.updateBalance({ myBalance, currentRate })
       // Update redux state
       _this.props.setWalletInfo(currentWallet)
-      _this.props.updateBalance({ myBalance, currentRate })
+      _this.props.updateBalance({ myBalance, currentRate, currency })
       _this.props.setBchWallet(bchWalletLib)
 
       // Reset form and component state

--- a/src/components/admin-lte/wallet/index.js
+++ b/src/components/admin-lte/wallet/index.js
@@ -19,7 +19,7 @@ class Wallet extends React.Component {
   render() {
     return (
       <Content>
-        <InfoWallets />
+        <InfoWallets walletInfo={_this.props.walletInfo} />
         {/* Show wallet info is this exists */}
         {_this.props.walletInfo.mnemonic && (
           <WalletInfo walletInfo={_this.props.walletInfo} />

--- a/src/components/admin-lte/wallet/info.js
+++ b/src/components/admin-lte/wallet/info.js
@@ -3,8 +3,13 @@ import React from 'react'
 import { Row, Col, Box } from 'adminlte-2-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
+let _this
 class InfoWallets extends React.Component {
-  // state = {}
+  constructor(props) {
+    super(props)
+    _this = this
+    this.state = {}
+  }
 
   render () {
     return (
@@ -26,8 +31,12 @@ class InfoWallets extends React.Component {
 
               <Col sm={12} className='text-center mt-2 mb-2'>
                 <p>
-                  This is an open source, non-custodial web wallet
-                  supporting Bitcoin Cash (BCH) and SLP tokens. Web wallets
+                  This is an open source, non-custodial web wallet supporting
+                  {_this.props.walletInfo.selectedServer ==
+                  'https://bchn.fullstack.cash/v5/'
+                    ? ' Bitcoin Cash (BCH) '
+                    : ' Ecash (XEC) '}
+                  and SLP tokens. Web wallets
                   offer user convenience, but they are inherently insecure and
                   bad for privacy.{' '}
                   <b>Storing large amounts of money on a web wallet is not

--- a/src/components/admin-lte/wallet/info.js
+++ b/src/components/admin-lte/wallet/info.js
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 let _this
 class InfoWallets extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
     _this = this
     this.state = {}
@@ -32,7 +32,7 @@ class InfoWallets extends React.Component {
               <Col sm={12} className='text-center mt-2 mb-2'>
                 <p>
                   This is an open source, non-custodial web wallet supporting
-                  {_this.props.walletInfo.selectedServer ==
+                  {_this.props.walletInfo.selectedServer ===
                   'https://bchn.fullstack.cash/v5/'
                     ? ' Bitcoin Cash (BCH) '
                     : ' Ecash (XEC) '}

--- a/src/components/menu-components.js
+++ b/src/components/menu-components.js
@@ -21,7 +21,12 @@ const MenuComponents = props => {
       key: 'Send/Receive BCH',
       component: <SendReceive key='Send/Receive BCH' {...props} />,
       menuItem: (
-        <Item icon='fa-exchange-alt' key='Send/Receive BCH' text='Send/Receive BCH' />
+        <Item icon='fa-exchange-alt' key='Send/Receive BCH' text={`Send/Receive ${
+          props.walletInfo.selectedServer == 'https://bchn.fullstack.cash/v5/'
+            ? 'BCH'
+            : 'XEC'
+          }`} 
+        />
       )
     },
     {

--- a/src/components/menu-components.js
+++ b/src/components/menu-components.js
@@ -21,11 +21,12 @@ const MenuComponents = props => {
       key: 'Send/Receive BCH',
       component: <SendReceive key='Send/Receive BCH' {...props} />,
       menuItem: (
-        <Item icon='fa-exchange-alt' key='Send/Receive BCH' text={`Send/Receive ${
-          props.walletInfo.selectedServer == 'https://bchn.fullstack.cash/v5/'
+        <Item
+          icon='fa-exchange-alt' key='Send/Receive BCH' text={`Send/Receive ${
+          props.walletInfo.selectedServer === 'https://bchn.fullstack.cash/v5/'
             ? 'BCH'
             : 'XEC'
-          }`} 
+          }`}
         />
       )
     },

--- a/src/components/site-config.js
+++ b/src/components/site-config.js
@@ -6,7 +6,6 @@
 const config = {
   title: 'FullStack.cash',
   titleShort: 'PSF',
-  balanceText: 'BCH Balance',
   balanceIcon: 'fab-bitcoin',
 
   // The BCH address used in a memo.cash account. Used for tracking the IPFS

--- a/src/redux/createStore.js
+++ b/src/redux/createStore.js
@@ -24,13 +24,15 @@ const reducer = (state, action) => {
   // Update bchBalance state property
   if (action.type === 'UPDATE_BALANCE') {
     // Convert satoshis to bch
-    const { myBalance, currentRate } = action.value
-    console.log(`currentRate: ${currentRate}`)
+    const { myBalance, currentRate, currency } = action.value
+    console.log(`currentRate ${currency}: ${currentRate} dollarcent`)
 
     const satoshis = myBalance
-    const bch = satoshis / 100000000
 
-    const bchBalance = Number(bch.toFixed(8))
+    let coin = satoshis / 100000000
+    if (currency === 'XEC') coin = satoshis / 100
+
+    const bchBalance = Number(coin.toFixed(8))
     const _usdBalance = bchBalance * (currentRate / 100)
     const usdBalance = Number(_usdBalance.toFixed(2)) // usd balance
 


### PR DESCRIPTION
Builds further on the rebranding to XEC of PR #153.

Comprehensive alternative to #155.
This version changes the store balance and current rate to the XEC denomination as well as every api call getting the getBchaUsd() to getXecUsd().

This automatically fixed the balance denomination to XEC. 

(in this PR, the state 'amountSat' was renamed to 'amountEntered' because it did not store the amount in sats.)

The change overlaps with the alternative in that the renaming of the labels and buttons in the send section works the same.
For this a new key 'Coin' was added to the state to change them conditionally.

The drawbacks are that it changes more files as well as the redux store, benefits are that it doesn't introduce magic conversion numbers like times a million or a millionth to convert balances or current rates from BCHA to XEC.
 